### PR TITLE
Referral and ipfs comments

### DIFF
--- a/contracts/map/Zone.sol
+++ b/contracts/map/Zone.sol
@@ -614,8 +614,6 @@ contract Zone is ERC223ReceivingContract {
       return; // just retun success
     }
 
-    require(users.getUserTier(_from) > 0, "user not certified");
-
     _processState();
 
     if (func == bytes1(0x41)) { // claimFreeZone
@@ -634,7 +632,6 @@ contract Zone is ERC223ReceivingContract {
   {
     require(control.paused() == false, "contract is paused");
     // allow also when country is disabled, otherwise no way for zone owner to get their eth/dth back
-    require(users.getUserTier(msg.sender) > 0, "user not certified");
 
     // zone owner could be removed if he does not have enough balance to pay his taxes
     _processState();
@@ -667,7 +664,6 @@ contract Zone is ERC223ReceivingContract {
   {
     require(control.paused() == false, "contract is paused");
     // even when country is disabled, otherwise users cannot withdraw their bids
-    require(users.getUserTier(msg.sender) > 0, "user not certified");
 
     require(_auctionId <= currentAuctionId, "auctionId does not exist");
 
@@ -688,7 +684,6 @@ contract Zone is ERC223ReceivingContract {
   {
     require(control.paused() == false, "contract is paused");
     // even when country is disabled, can withdraw
-    require(users.getUserTier(msg.sender) > 0, "user not certified");
 
     _processState();
 
@@ -758,7 +753,6 @@ contract Zone is ERC223ReceivingContract {
   {
     require(control.paused() == false, "contract is paused");
     require(geo.countryIsEnabled(country), "country is disabled");
-    require(users.getUserTier(msg.sender) > 0, "user not certified");
     require(_position.length == 10, "expected position to be 10 bytes");
     require(toBytes7(_position, 0) == geohash, "position is not inside this zone");
     require(geo.validGeohashChars(_position), "invalid position geohash characters");
@@ -800,7 +794,6 @@ contract Zone is ERC223ReceivingContract {
   {
     require(control.paused() == false, "contract is paused");
     require(geo.countryIsEnabled(country), "country is disabled");
-    require(users.getUserTier(msg.sender) > 0, "user not certified");
     require(msg.value > 0, "no eth send with call");
 
     _processState();
@@ -818,7 +811,6 @@ contract Zone is ERC223ReceivingContract {
   {
     require(control.paused() == false, "contract is paused");
     require(geo.countryIsEnabled(country), "country is disabled");
-    require(users.getUserTier(msg.sender) > 0, "user not certified");
     require(msg.sender != _to, "sender cannot also be to");
     require(_amount > 0, "amount to sell cannot be zero");
 

--- a/contracts/map/Zone.sol
+++ b/contracts/map/Zone.sol
@@ -57,7 +57,7 @@ contract Zone is ERC223ReceivingContract {
   struct Teller {
     uint8 currencyId;  // 1 - 100 , see README
     bytes16 messenger; // telegrame nickname
-    bytes10 position;  // 10 char geohash for location of teller
+    bytes12 position;  // 12 char geohash for location of teller
     bytes1 settings;   // bitmask containing up to 8 boolean settings (only 2 used currently: isSeller, isBuyer)
     // TODO: wouldn't it be wiser to use uint256, to make all calculations cost less
     int16 buyRate;     // margin of tellers , -999 - +9999 , corresponding to -99,9% x 10  , 999,9% x 10
@@ -283,7 +283,7 @@ contract Zone is ERC223ReceivingContract {
   function getTeller()
     external
     view
-    returns (uint8, bytes16, bytes10, bytes1, int16, int16, uint, address)
+    returns (uint8, bytes16, bytes12, bytes1, int16, int16, uint, address)
   {
     return (
       teller.currencyId,
@@ -329,18 +329,18 @@ contract Zone is ERC223ReceivingContract {
 
       return tempBytes7;
   }
-  function toBytes10(bytes _bytes, uint _start)
+  function toBytes12(bytes _bytes, uint _start)
     private
     pure
-    returns (bytes10) {
-      require(_bytes.length >= (_start + 10), " not long enough");
-      bytes10 tempBytes10;
+    returns (bytes12) {
+      require(_bytes.length >= (_start + 12), " not long enough");
+      bytes12 tempBytes12;
 
       assembly {
-          tempBytes10 := mload(add(add(_bytes, 0x20), _start))
+          tempBytes12 := mload(add(add(_bytes, 0x20), _start))
       }
 
-      return tempBytes10;
+      return tempBytes12;
   }
 
   // ------------------------------------------------
@@ -745,7 +745,7 @@ contract Zone is ERC223ReceivingContract {
   /////////////
 
 
-  // NOTE: we could just require only last 3 bytes of a bytes10 geohash, since
+  // NOTE: we could just require only last 5 bytes of a bytes12 geohash, since
   // the first 7 bytes will be the geohash of this zone. But by requiring the full geohash
   // we can mkae more sure the user is talking to the right zone
   function addTeller(bytes _position, uint8 _currencyId, bytes16 _messenger, int16 _sellRate, int16 _buyRate, bytes1 _settings, address _referrer) // GAS COST +/- 75.301
@@ -753,7 +753,7 @@ contract Zone is ERC223ReceivingContract {
   {
     require(control.paused() == false, "contract is paused");
     require(geo.countryIsEnabled(country), "country is disabled");
-    require(_position.length == 10, "expected position to be 10 bytes");
+    require(_position.length == 12, "expected position to be 10 bytes");
     require(toBytes7(_position, 0) == geohash, "position is not inside this zone");
     require(geo.validGeohashChars(_position), "invalid position geohash characters");
 

--- a/contracts/map/ZoneFactory.sol
+++ b/contracts/map/ZoneFactory.sol
@@ -190,8 +190,7 @@ contract ZoneFactory is Ownable {
     require(geo.countryIsEnabled(country), "country is disabled");
     require(geo.zoneInsideCountry(country, bytes4(geohash)), "zone is not inside country");
     require(geohashToZone[geohash] == address(0), "zone already exists");
-    require(users.getUserTier(sender) > 0, "user not certified");
-
+    
     // create/deploy the new zone
     geohashToZone[geohash] = new Zone(
       country, geohash, sender, dthAmount,

--- a/test/map/ZoneFactory-Zone.spec.js
+++ b/test/map/ZoneFactory-Zone.spec.js
@@ -868,7 +868,7 @@ contract('ZoneFactory + Zone', () => {
     });
 
     describe('TELLER', () => {
-      const VALID_POSITION = asciiToHex('krcztsebcd');
+      const VALID_TELLER_POSITION = asciiToHex('krcztsebcddd');
       const VALID_CURRENCY_ID = '1';
       const VALID_MESSENGER = asciiToHex('my_telegram_nick');
       const VALID_SELLRATE = '177'; // 1.77%
@@ -884,14 +884,14 @@ contract('ZoneFactory + Zone', () => {
         it('[error] -- global pause is enabled', async () => {
           await controlInstance.pause({ from: owner });
           await expectRevert(
-            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
+            zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'contract is paused',
           );
         });
         it('[error] -- country is disabled', async () => {
           await geoInstance.disableCountry(COUNTRY_CG, { from: owner });
           await expectRevert(
-            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
+            zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'country is disabled',
           );
         });
@@ -901,13 +901,13 @@ contract('ZoneFactory + Zone', () => {
             'expected position to be 10 bytes',
           );
         });
-        it('[error] -- position is 9 bytes (instead of expected 10)', async () => {
+        it('[error] -- position is 9 bytes (instead of expected 12)', async () => {
           await expectRevert(
             zoneInstance.addTeller(asciiToHex('krcztsebc'), VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'expected position to be 10 bytes',
           );
         });
-        it('[error] -- position is 11 bytes (instead of expected 10)', async () => {
+        it('[error] -- position is 11 bytes (instead of expected 12)', async () => {
           await expectRevert(
             zoneInstance.addTeller(asciiToHex('krcztsebcde'), VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'expected position to be 10 bytes',
@@ -915,77 +915,77 @@ contract('ZoneFactory + Zone', () => {
         });
         it('[error] -- position does not match geohash of Zone contract', async () => {
           await expectRevert(
-            zoneInstance.addTeller(asciiToHex('xxxxxxxbcd'), VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
+            zoneInstance.addTeller(asciiToHex('xxxxxxxbcddd'), VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'position is not inside this zone',
           );
         });
         it('[error] -- position last 3 chars contain invalid geohash char', async () => {
           await expectRevert(
             // a is not a valid geohash char
-            zoneInstance.addTeller(asciiToHex('krcztsebca'), VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
+            zoneInstance.addTeller(asciiToHex('krcztsebcdda'), VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'invalid position geohash characters',
           );
         });
         it('[error] -- currency id is zero', async () => {
           await expectRevert(
-            zoneInstance.addTeller(VALID_POSITION, '0', VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
+            zoneInstance.addTeller(VALID_TELLER_POSITION, '0', VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'currency id must be in range 1-100',
           );
         });
         it('[error] -- currency id is 101', async () => {
           await expectRevert(
-            zoneInstance.addTeller(VALID_POSITION, '101', VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
+            zoneInstance.addTeller(VALID_TELLER_POSITION, '101', VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'currency id must be in range 1-100',
           );
         });
         it('[error] -- seller bit set -- sellrate less than -9999', async () => {
           await expectRevert(
-            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, '-10000', VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
+            zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, '-10000', VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'sellRate should be between -9999 and 9999',
           );
         });
         it('[error] -- seller bit set -- sellrate more than than 9999', async () => {
           await expectRevert(
-            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, '10000', VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
+            zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, '10000', VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'sellRate should be between -9999 and 9999',
           );
         });
         it('[error] -- seller bit not set -- sellrate is not zero', async () => {
           await expectRevert(
-            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, '1', VALID_BUYRATE, '0x02', ADDRESS_ZERO, { from: user1 }),
+            zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, '1', VALID_BUYRATE, '0x02', ADDRESS_ZERO, { from: user1 }),
             'cannot set sellRate if not set as seller',
           );
         });
         it('[error] -- buyer bit set -- sellrate less than -9999', async () => {
           await expectRevert(
-            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, '-10000', VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
+            zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, '-10000', VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'buyRate should be between -9999 and 9999',
           );
         });
         it('[error] -- buyer bit set -- buyrate more than than 9999', async () => {
           await expectRevert(
-            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, '10000', VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
+            zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, '10000', VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'buyRate should be between -9999 and 9999',
           );
         });
         it('[error] -- buyer bit not set -- buyrate is not zero', async () => {
           await expectRevert(
-            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, '1', '0x01', ADDRESS_ZERO, { from: user1 }),
+            zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, '1', '0x01', ADDRESS_ZERO, { from: user1 }),
             'cannot set buyRate if not set as buyer',
           );
         });
         it('[error] -- caller is not zone owner', async () => {
           await expectRevert(
-            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user2 }),
+            zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user2 }),
             'only zone owner can add teller info',
           );
         });
         it('[success] messenger can be bytes16(0)', async () => {
-          const tx = await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, '0x00000000000000000000000000000000', VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
+          const tx = await zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, '0x00000000000000000000000000000000', VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           // console.log('addTeller gas used:', addNumberDots(tx.receipt.gasUsed));
         });
         it('[success]', async () => {
-          const tx = await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
+          const tx = await zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           // console.log('addTeller gas used:', addNumberDots(tx.receipt.gasUsed));
         });
       });
@@ -996,7 +996,7 @@ contract('ZoneFactory + Zone', () => {
           zoneInstance = await createZone(user1, MIN_ZONE_DTH_STAKE, COUNTRY_CG, VALID_CG_ZONE_GEOHASH);
         });
         it('[error] -- global pause is enabled', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
+          await zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           await controlInstance.pause({ from: owner });
           await expectRevert(
             zoneInstance.addFunds({ from: user1, value: ethToWei(100) }),
@@ -1004,7 +1004,7 @@ contract('ZoneFactory + Zone', () => {
           );
         });
         it('[error] -- country is disabled', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
+          await zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           await geoInstance.disableCountry(COUNTRY_CG, { from: owner });
           await expectRevert(
             zoneInstance.addFunds({ from: user1, value: ethToWei(100) }),
@@ -1012,14 +1012,14 @@ contract('ZoneFactory + Zone', () => {
           );
         });
         it('[error] -- no eth send with call', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
+          await zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           await expectRevert(
             zoneInstance.addFunds({ from: user1, value: ethToWei(0) }),
             'no eth send with call',
           );
         });
         it('[error] -- called by not-zoneowner', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
+          await zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           await expectRevert(
             zoneInstance.addFunds({ from: user2, value: ethToWei(100) }),
             'only zoneOwner can add funds',
@@ -1032,7 +1032,7 @@ contract('ZoneFactory + Zone', () => {
           );
         });
         it('[success]', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
+          await zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           const tx = await zoneInstance.addFunds({ from: user1, value: ethToWei(100) });
           // console.log('addFunds gas used:', addNumberDots(tx.receipt.gasUsed));
         });
@@ -1045,7 +1045,7 @@ contract('ZoneFactory + Zone', () => {
           await geoInstance.setCountryTierDailyLimit(COUNTRY_CG, '0', '1000', { from: owner });
         });
         it('[error] -- global pause is enabled', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
+          await zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           await zoneInstance.addFunds({ from: user1, value: ethToWei(1) });
           await controlInstance.pause({ from: owner });
           await expectRevert(
@@ -1054,7 +1054,7 @@ contract('ZoneFactory + Zone', () => {
           );
         });
         it('[error] -- country is disabled', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
+          await zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           await zoneInstance.addFunds({ from: user1, value: ethToWei(1) });
           await geoInstance.disableCountry(COUNTRY_CG, { from: owner });
           await expectRevert(
@@ -1063,7 +1063,7 @@ contract('ZoneFactory + Zone', () => {
           );
         });
         it('[error] -- sender is also to', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
+          await zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           await zoneInstance.addFunds({ from: user1, value: ethToWei(1) });
           await expectRevert(
             zoneInstance.sellEth(user1, ethToWei(1), { from: user1 }),
@@ -1071,7 +1071,7 @@ contract('ZoneFactory + Zone', () => {
           );
         });
         it('[error] -- amount is zero', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
+          await zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           await zoneInstance.addFunds({ from: user1, value: ethToWei(1) });
           await expectRevert(
             zoneInstance.sellEth(user3, ethToWei(0), { from: user1 }),
@@ -1079,7 +1079,7 @@ contract('ZoneFactory + Zone', () => {
           );
         });
         it('[error] -- caller is not zoneowner', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
+          await zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           await zoneInstance.addFunds({ from: user1, value: ethToWei(1) });
           await expectRevert(
             zoneInstance.sellEth(user3, ethToWei(1), { from: user2 }),
@@ -1093,7 +1093,7 @@ contract('ZoneFactory + Zone', () => {
           );
         });
         it('[error] -- amount to sell is greater than funds added', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
+          await zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           await zoneInstance.addFunds({ from: user1, value: ethToWei(1) });
           await expectRevert(
             zoneInstance.sellEth(user3, ethToWei(1.1), { from: user1 }),
@@ -1101,7 +1101,7 @@ contract('ZoneFactory + Zone', () => {
           );
         });
         it('[error] -- amount to sell is not enough pay 0.1% referrer fee', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, user4, { from: user1 });
+          await zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, user4, { from: user1 });
           await zoneInstance.addFunds({ from: user1, value: ethToWei(1) });
           await expectRevert(
             zoneInstance.sellEth(user3, ethToWei(1), { from: user1 }),
@@ -1109,7 +1109,7 @@ contract('ZoneFactory + Zone', () => {
           );
         });
         it('[error] -- amount to sell is greater than daily limit', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
+          await zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           await zoneInstance.addFunds({ from: user1, value: ethToWei(2) });
           await expectRevert(
             zoneInstance.sellEth(user3, ethToWei(2), { from: user1 }),
@@ -1117,7 +1117,7 @@ contract('ZoneFactory + Zone', () => {
           );
         });
         it('[success] - no referrer', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
+          await zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           const ethToSend = toBN(ethToWei(1));
           await zoneInstance.addFunds({ from: user1, value: ethToSend });
           const sellerFundsBefore = await zoneInstance.funds(user1);
@@ -1130,7 +1130,7 @@ contract('ZoneFactory + Zone', () => {
           // console.log('sell eth gas used:', addNumberDots(tx.receipt.gasUsed));
         });
         it('[success] - with referrer paid out 0.1% on top of sold eth', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, user4, { from: user1 });
+          await zoneInstance.addTeller(VALID_TELLER_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, user4, { from: user1 });
           await zoneInstance.addFunds({ from: user1, value: ethToWei(1.001) });
           const buyerBalanceBefore = toBN(await web3.eth.getBalance(user3));
           const tx = await zoneInstance.sellEth(user3, ethToWei(1), { from: user1 });

--- a/test/map/ZoneFactory-Zone.spec.js
+++ b/test/map/ZoneFactory-Zone.spec.js
@@ -17,11 +17,11 @@ const Web3 = require('web3');
 const TimeTravel = require('../utils/timeTravel');
 const { getAccounts } = require('../utils/accounts');
 const { addCountry } = require('../utils/geo');
-const { ethToWei, asciiToHex } = require('../utils/convert');
+const { ethToWei, asciiToHex, toBN } = require('../utils/convert');
 const { expectRevert, expectRevert2 } = require('../utils/evmErrors');
 const {
   BYTES7_ZERO, VALID_CG_ZONE_GEOHASH, INVALID_CG_ZONE_GEOHASH, MIN_ZONE_DTH_STAKE,
-  ONE_HOUR, ONE_DAY, BID_PERIOD, COOLDOWN_PERIOD,
+  ONE_HOUR, ONE_DAY, BID_PERIOD, COOLDOWN_PERIOD, ADDRESS_ZERO,
 } = require('../utils/values');
 
 const web3 = new Web3('http://localhost:8545');
@@ -911,116 +911,116 @@ contract('ZoneFactory + Zone', () => {
         it('[error] -- global pause is enabled', async () => {
           await controlInstance.pause({ from: owner });
           await expectRevert(
-            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 }),
+            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'contract is paused',
           );
         });
         it('[error] -- country is disabled', async () => {
           await geoInstance.disableCountry(COUNTRY_CG, { from: owner });
           await expectRevert(
-            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 }),
+            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'country is disabled',
           );
         });
         it('[error] -- user not certified', async () => {
           await smsInstance.revoke(user1, { from: owner });
           await expectRevert(
-            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 }),
+            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'user not certified',
           );
         });
         it('[error] -- position is empty bytes array', async () => {
           await expectRevert(
-            zoneInstance.addTeller('0x', VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 }),
+            zoneInstance.addTeller('0x', VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'expected position to be 10 bytes',
           );
         });
         it('[error] -- position is 9 bytes (instead of expected 10)', async () => {
           await expectRevert(
-            zoneInstance.addTeller(asciiToHex('krcztsebc'), VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 }),
+            zoneInstance.addTeller(asciiToHex('krcztsebc'), VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'expected position to be 10 bytes',
           );
         });
         it('[error] -- position is 11 bytes (instead of expected 10)', async () => {
           await expectRevert(
-            zoneInstance.addTeller(asciiToHex('krcztsebcde'), VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 }),
+            zoneInstance.addTeller(asciiToHex('krcztsebcde'), VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'expected position to be 10 bytes',
           );
         });
         it('[error] -- position does not match geohash of Zone contract', async () => {
           await expectRevert(
-            zoneInstance.addTeller(asciiToHex('xxxxxxxbcd'), VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 }),
+            zoneInstance.addTeller(asciiToHex('xxxxxxxbcd'), VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'position is not inside this zone',
           );
         });
         it('[error] -- position last 3 chars contain invalid geohash char', async () => {
           await expectRevert(
             // a is not a valid geohash char
-            zoneInstance.addTeller(asciiToHex('krcztsebca'), VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 }),
+            zoneInstance.addTeller(asciiToHex('krcztsebca'), VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'invalid position geohash characters',
           );
         });
         it('[error] -- currency id is zero', async () => {
           await expectRevert(
-            zoneInstance.addTeller(VALID_POSITION, '0', VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 }),
+            zoneInstance.addTeller(VALID_POSITION, '0', VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'currency id must be in range 1-100',
           );
         });
         it('[error] -- currency id is 101', async () => {
           await expectRevert(
-            zoneInstance.addTeller(VALID_POSITION, '101', VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 }),
+            zoneInstance.addTeller(VALID_POSITION, '101', VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'currency id must be in range 1-100',
           );
         });
         it('[error] -- seller bit set -- sellrate less than -9999', async () => {
           await expectRevert(
-            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, '-10000', VALID_BUYRATE, VALID_SETTINGS, { from: user1 }),
+            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, '-10000', VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'sellRate should be between -9999 and 9999',
           );
         });
         it('[error] -- seller bit set -- sellrate more than than 9999', async () => {
           await expectRevert(
-            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, '10000', VALID_BUYRATE, VALID_SETTINGS, { from: user1 }),
+            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, '10000', VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'sellRate should be between -9999 and 9999',
           );
         });
         it('[error] -- seller bit not set -- sellrate is not zero', async () => {
           await expectRevert(
-            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, '1', VALID_BUYRATE, '0x02', { from: user1 }),
+            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, '1', VALID_BUYRATE, '0x02', ADDRESS_ZERO, { from: user1 }),
             'cannot set sellRate if not set as seller',
           );
         });
         it('[error] -- buyer bit set -- sellrate less than -9999', async () => {
           await expectRevert(
-            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, '-10000', VALID_SETTINGS, { from: user1 }),
+            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, '-10000', VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'buyRate should be between -9999 and 9999',
           );
         });
         it('[error] -- buyer bit set -- buyrate more than than 9999', async () => {
           await expectRevert(
-            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, '10000', VALID_SETTINGS, { from: user1 }),
+            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, '10000', VALID_SETTINGS, ADDRESS_ZERO, { from: user1 }),
             'buyRate should be between -9999 and 9999',
           );
         });
         it('[error] -- buyer bit not set -- buyrate is not zero', async () => {
           await expectRevert(
-            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, '1', '0x01', { from: user1 }),
+            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, '1', '0x01', ADDRESS_ZERO, { from: user1 }),
             'cannot set buyRate if not set as buyer',
           );
         });
         it('[error] -- caller is not zone owner', async () => {
           await smsInstance.certify(user2, { from: owner });
           await expectRevert(
-            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user2 }),
+            zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user2 }),
             'only zone owner can add teller info',
           );
         });
         it('[success] messenger can be bytes16(0)', async () => {
-          const tx = await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, '0x00000000000000000000000000000000', VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 });
+          const tx = await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, '0x00000000000000000000000000000000', VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           // console.log('addTeller gas used:', addNumberDots(tx.receipt.gasUsed));
         });
         it('[success]', async () => {
-          const tx = await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 });
+          const tx = await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           // console.log('addTeller gas used:', addNumberDots(tx.receipt.gasUsed));
         });
       });
@@ -1031,7 +1031,7 @@ contract('ZoneFactory + Zone', () => {
           zoneInstance = await createZone(user1, MIN_ZONE_DTH_STAKE, COUNTRY_CG, VALID_CG_ZONE_GEOHASH);
         });
         it('[error] -- global pause is enabled', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 });
+          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           await controlInstance.pause({ from: owner });
           await expectRevert(
             zoneInstance.addFunds({ from: user1, value: ethToWei(100) }),
@@ -1039,7 +1039,7 @@ contract('ZoneFactory + Zone', () => {
           );
         });
         it('[error] -- country is disabled', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 });
+          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           await geoInstance.disableCountry(COUNTRY_CG, { from: owner });
           await expectRevert(
             zoneInstance.addFunds({ from: user1, value: ethToWei(100) }),
@@ -1047,7 +1047,7 @@ contract('ZoneFactory + Zone', () => {
           );
         });
         it('[error] -- user not certified', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 });
+          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           await smsInstance.revoke(user1, { from: owner });
           await expectRevert(
             zoneInstance.addFunds({ from: user1, value: ethToWei(100) }),
@@ -1055,14 +1055,14 @@ contract('ZoneFactory + Zone', () => {
           );
         });
         it('[error] -- no eth send with call', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 });
+          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           await expectRevert(
             zoneInstance.addFunds({ from: user1, value: ethToWei(0) }),
             'no eth send with call',
           );
         });
         it('[error] -- called by not-zoneowner', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 });
+          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           await smsInstance.certify(user2, { from: owner });
           await expectRevert(
             zoneInstance.addFunds({ from: user2, value: ethToWei(100) }),
@@ -1076,7 +1076,7 @@ contract('ZoneFactory + Zone', () => {
           );
         });
         it('[success]', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 });
+          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           const tx = await zoneInstance.addFunds({ from: user1, value: ethToWei(100) });
           // console.log('addFunds gas used:', addNumberDots(tx.receipt.gasUsed));
         });
@@ -1089,7 +1089,7 @@ contract('ZoneFactory + Zone', () => {
           await geoInstance.setCountryTierDailyLimit(COUNTRY_CG, '1', '1000', { from: owner });
         });
         it('[error] -- global pause is enabled', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 });
+          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           await zoneInstance.addFunds({ from: user1, value: ethToWei(1) });
           await controlInstance.pause({ from: owner });
           await expectRevert(
@@ -1098,7 +1098,7 @@ contract('ZoneFactory + Zone', () => {
           );
         });
         it('[error] -- country is disabled', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 });
+          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           await zoneInstance.addFunds({ from: user1, value: ethToWei(1) });
           await geoInstance.disableCountry(COUNTRY_CG, { from: owner });
           await expectRevert(
@@ -1107,7 +1107,7 @@ contract('ZoneFactory + Zone', () => {
           );
         });
         it('[error] -- user not certified', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 });
+          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           await zoneInstance.addFunds({ from: user1, value: ethToWei(1) });
           await smsInstance.revoke(user1, { from: owner });
           await expectRevert(
@@ -1116,7 +1116,7 @@ contract('ZoneFactory + Zone', () => {
           );
         });
         it('[error] -- sender is also to', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 });
+          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           await zoneInstance.addFunds({ from: user1, value: ethToWei(1) });
           await expectRevert(
             zoneInstance.sellEth(user1, ethToWei(1), { from: user1 }),
@@ -1124,7 +1124,7 @@ contract('ZoneFactory + Zone', () => {
           );
         });
         it('[error] -- amount is zero', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 });
+          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           await zoneInstance.addFunds({ from: user1, value: ethToWei(1) });
           await expectRevert(
             zoneInstance.sellEth(user3, ethToWei(0), { from: user1 }),
@@ -1132,7 +1132,7 @@ contract('ZoneFactory + Zone', () => {
           );
         });
         it('[error] -- caller is not zoneowner', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 });
+          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           await zoneInstance.addFunds({ from: user1, value: ethToWei(1) });
           await smsInstance.certify(user2, { from: owner });
           await expectRevert(
@@ -1147,25 +1147,53 @@ contract('ZoneFactory + Zone', () => {
           );
         });
         it('[error] -- amount to sell is greater than funds added', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 });
+          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           await zoneInstance.addFunds({ from: user1, value: ethToWei(1) });
           await expectRevert(
             zoneInstance.sellEth(user3, ethToWei(1.1), { from: user1 }),
             'cannot sell more than in funds',
           );
         });
+        it('[error] -- amount to sell is not enough pay 0.1% referrer fee', async () => {
+          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, user4, { from: user1 });
+          await zoneInstance.addFunds({ from: user1, value: ethToWei(1) });
+          await expectRevert(
+            zoneInstance.sellEth(user3, ethToWei(1), { from: user1 }),
+            'not enough funds to sell eth amount plus pay referrer fee',
+          );
+        });
         it('[error] -- amount to sell is greater than daily limit', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 });
+          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
           await zoneInstance.addFunds({ from: user1, value: ethToWei(2) });
           await expectRevert(
             zoneInstance.sellEth(user3, ethToWei(2), { from: user1 }),
             'exceeded daily sell limit',
           );
         });
-        it('[success]', async () => {
-          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, { from: user1 });
-          await zoneInstance.addFunds({ from: user1, value: ethToWei(1) });
+        it('[success] - no referrer', async () => {
+          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, ADDRESS_ZERO, { from: user1 });
+          const ethToSend = toBN(ethToWei(1));
+          await zoneInstance.addFunds({ from: user1, value: ethToSend });
+          const sellerFundsBefore = await zoneInstance.funds(user1);
+          const buyerBalanceBefore = toBN(await web3.eth.getBalance(user3));
+          const tx = await zoneInstance.sellEth(user3, ethToSend.toString(), { from: user1 });
+          const sellerFundsAfter = await zoneInstance.funds(user1);
+          const buyerBalanceAfter = toBN(await web3.eth.getBalance(user3));
+          expect(sellerFundsBefore.sub(ethToSend).eq(sellerFundsAfter)).to.equal(true);
+          expect(buyerBalanceBefore.add(ethToSend).eq(buyerBalanceAfter)).to.equal(true);
+          // console.log('sell eth gas used:', addNumberDots(tx.receipt.gasUsed));
+        });
+        it('[success] - with referrer paid out 0.1% on top of sold eth', async () => {
+          await zoneInstance.addTeller(VALID_POSITION, VALID_CURRENCY_ID, VALID_MESSENGER, VALID_SELLRATE, VALID_BUYRATE, VALID_SETTINGS, user4, { from: user1 });
+          await zoneInstance.addFunds({ from: user1, value: ethToWei(1.001) });
+          const buyerBalanceBefore = toBN(await web3.eth.getBalance(user3));
           const tx = await zoneInstance.sellEth(user3, ethToWei(1), { from: user1 });
+          const sellerFundsAfter = await zoneInstance.funds(user1);
+          const referrerWithdrawableEth = await zoneInstance.withdrawableEth(user4);
+          const buyerBalanceAfter = toBN(await web3.eth.getBalance(user3));
+          expect(sellerFundsAfter.eq(0)).to.equal(true);
+          expect(buyerBalanceBefore.add(toBN(ethToWei(1))).eq(buyerBalanceAfter)).to.equal(true);
+          expect(referrerWithdrawableEth.eq(toBN(ethToWei(0.001)))).to.equal(true);
           // console.log('sell eth gas used:', addNumberDots(tx.receipt.gasUsed));
         });
       });

--- a/test/utils/convert.js
+++ b/test/utils/convert.js
@@ -2,11 +2,13 @@ const Web3 = require('web3');
 
 const web3 = new Web3();
 
+const toBN = val => web3.utils.toBN(val);
 const ethToWei = eth => web3.utils.toWei(eth.toString(), 'ether');
 const asciiToHex = ascii => web3.utils.asciiToHex(ascii);
 const remove0x = txt => txt.startsWith('0x') ? txt.slice(2) : txt; // eslint-disable-line
 
 module.exports = {
+  toBN,
   ethToWei,
   asciiToHex,
   remove0x,

--- a/test/utils/ipfs.js
+++ b/test/utils/ipfs.js
@@ -1,0 +1,10 @@
+const Web3 = require('web3');
+const web3 = new Web3();
+
+const getRandomBytes32 = () => (
+  web3.utils.randomHex(32)
+);
+
+module.exports = {
+  getRandomBytes32,
+};


### PR DESCRIPTION
- made it possible for non-certified users to use zones/tellers
- added `removeTeller`/`removeZoneOwner` functions to `Zone.sol`
- refactored removal of zoneowner/teller in `Zone.sol`
- implemented certified/free comments on teller of a zone
- implemented referrer for tellers (referrer gets 0.1% of each eth sell trade)
- updated geohash of teller to geohash 12 instead of geohash 10, since shops also use geohash 12